### PR TITLE
Fix for error preventing playback when selecting episodes directly on Android devices.

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -288,7 +288,7 @@ def GetGroupEpisodes(server_id, group_id, name="", page=1):
 
 
 ################################################################################
-def GetEpisode(instance_id, title, summary, show, season, episode, duration, url, thumb, container=False):
+def GetEpisode(instance_id, title, summary, show, season, episode, duration, url, thumb, container=False, *args, **kwargs):
 
     # the double-callback method so that we don't have to have a URL service
     try:


### PR DESCRIPTION
TypeError: GetEpisode() got an unexpected keyword argument
'includeRelated' was preventing episode selection & playback on android
based devices (maybe others as well).  The patch allows the GetEpisode
function accept an arbitrary number of arguments, thereby preventing the
error and allowing episode selection and playback.